### PR TITLE
fix(algoliasearch): correct typo in readme

### DIFF
--- a/packages/algoliasearch/README.md
+++ b/packages/algoliasearch/README.md
@@ -58,7 +58,7 @@ dart pub add algoliasearch
 #### For Flutter projects:
 
 ```shell
-flutter pub add algolisearch
+flutter pub add algoliasearch
 ```
 
 ### Step 2: Import the Package


### PR DESCRIPTION
Corrected typo in README for algoliasearch (s/algolisearch/algoliasearch/ in flutter command).