### PR TITLE
feat: Add Dio HttpClientAdapter to ClientOptions

### DIFF
--- a/packages/client_core/lib/src/config/client_options.dart
+++ b/packages/client_core/lib/src/config/client_options.dart
@@ -34,17 +34,23 @@ final class ClientOptions {
   /// Used only in case of using the default (dio) requester.
   final Iterable<Interceptor>? interceptors;
 
+  /// Custom HttpClientAdapter used to send HTTP requests.
+  /// Used only in case of using the default (dio) requester.
+  final HttpClientAdapter? httpClientAdapter;
+
   /// Constructs a [ClientOptions] instance with the provided parameters.
-  const ClientOptions(
-      {this.connectTimeout = const Duration(seconds: 2),
-      this.writeTimeout = const Duration(seconds: 30),
-      this.readTimeout = const Duration(seconds: 5),
-      this.hosts,
-      this.headers,
-      this.agentSegments,
-      this.requester,
-      this.logger,
-      this.interceptors});
+  const ClientOptions({
+    this.connectTimeout = const Duration(seconds: 2),
+    this.writeTimeout = const Duration(seconds: 30),
+    this.readTimeout = const Duration(seconds: 5),
+    this.hosts,
+    this.headers,
+    this.agentSegments,
+    this.requester,
+    this.logger,
+    this.interceptors,
+    this.httpClientAdapter,
+  });
 
   @override
   bool operator ==(Object other) =>
@@ -59,7 +65,8 @@ final class ClientOptions {
           agentSegments == other.agentSegments &&
           logger == other.logger &&
           requester == other.requester &&
-          interceptors == other.interceptors;
+          interceptors == other.interceptors &&
+          httpClientAdapter == other.httpClientAdapter;
 
   @override
   int get hashCode =>
@@ -71,10 +78,11 @@ final class ClientOptions {
       agentSegments.hashCode ^
       logger.hashCode ^
       requester.hashCode ^
-      interceptors.hashCode;
+      interceptors.hashCode ^
+      httpClientAdapter.hashCode;
 
   @override
   String toString() {
-    return 'ClientOptions{hosts: $hosts, connectTimeout: $connectTimeout, writeTimeout: $writeTimeout, readTimeout: $readTimeout, headers: $headers, agentSegments: $agentSegments, logger: $logger, requester: $requester, interceptors: $interceptors}';
+    return 'ClientOptions{hosts: $hosts, connectTimeout: $connectTimeout, writeTimeout: $writeTimeout, readTimeout: $readTimeout, headers: $headers, agentSegments: $agentSegments, logger: $logger, requester: $requester, interceptors: $interceptors, httpClientAdapter: $httpClientAdapter}';
   }
 }

--- a/packages/client_core/lib/src/config/client_options.dart
+++ b/packages/client_core/lib/src/config/client_options.dart
@@ -34,7 +34,7 @@ final class ClientOptions {
   /// Used only in case of using the default (dio) requester.
   final Iterable<Interceptor>? interceptors;
 
-  /// Custom HttpClientAdapter used to send HTTP requests.
+  /// Custom [HttpClientAdapter] used to send HTTP requests.
   /// Used only in case of using the default (dio) requester.
   final HttpClientAdapter? httpClientAdapter;
 

--- a/packages/client_core/lib/src/transport/dio/dio_requester.dart
+++ b/packages/client_core/lib/src/transport/dio/dio_requester.dart
@@ -27,6 +27,7 @@ class DioRequester implements Requester {
     Iterable<AgentSegment>? clientSegments,
     Function(Object?)? logger,
     Iterable<Interceptor>? interceptors,
+    HttpClientAdapter? httpClientAdapter,
   }) : _client = Dio(
           BaseOptions(
             headers: headers,
@@ -49,7 +50,11 @@ class DioRequester implements Requester {
                 logPrint: logger,
               ),
             if (interceptors != null) ...interceptors,
-          ]);
+          ]) {
+    if (httpClientAdapter != null) {
+      _client.httpClientAdapter = httpClientAdapter;
+    }
+  }
 
   @override
   Future<HttpResponse> perform(HttpRequest request) async {

--- a/packages/client_core/lib/src/transport/retry_strategy.dart
+++ b/packages/client_core/lib/src/transport/retry_strategy.dart
@@ -39,6 +39,7 @@ final class RetryStrategy {
                 clientSegments: [segment, ...?options.agentSegments],
                 logger: options.logger,
                 interceptors: options.interceptors,
+                httpClientAdapter: options.httpClientAdapter,
               ),
         );
 


### PR DESCRIPTION
This PR gives the user the ability to optionally provide a custom Dio [`HttpClientAdapter`](https://pub.dev/documentation/dio/latest/dio/HttpClientAdapter-class.html), i.e.

```dart
final SearchClient client = SearchClient(
  appId: 'latency',
  apiKey: '6be0576ff61c053d5f9a3225e2a90f76',
  defaultHosts: () => const [
    Host(url: 'latency-dsn.algolia.net'),
    Host(url: 'latency-1.algolianet.com'),
  ],
  options: ClientOptions(
    httpClientAdapter: NativeAdapter(), // <-- from https://pub.dev/packages/native_dio_adapter
  ),
);
```

Via this option users can configure [Dio](https://pub.dev/packages/dio) to use [native_dio_adapter](https://pub.dev/packages/native_dio_adapter) which uses [cupertino_http](https://pub.dev/packages/cupertino_http) on iOS and [cronet_http](https://pub.dev/packages/cronet_http) on Android to delegate HTTP requests to the native platform instead of the `dart:io` platforms.

The advantages of using [cronet_http](https://pub.dev/packages/cronet_http) are:
 - It automatically supports Android platform features such as HTTP proxies.
 - It supports configurable caching.
 - It supports more HTTP features such as HTTP/3.

The advantages of using [cupertino_http](https://pub.dev/packages/cupertino_http) are:
- It automatically supports iOS/macOS platform features such VPNs and HTTP proxies.
- It supports many more configuration options such as only allowing access through WiFi and blocking cookies.
- It supports more HTTP features such as HTTP/3 and custom redirect handling.

---

Addresses #12